### PR TITLE
Google OAuth2 권한 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,6 +34,8 @@ jobs:
             --env-file /home/ubuntu/.env \
             -e KEY_PEM='${{ secrets.KEY_PEM }}' \
             -e CERT_PEM='${{ secrets.CERT_PEM }}' \
+            -e GOOGLE_CLIENT_ID='${{ secrets.GOOGLE_CLIENT_ID }}' \
+            -e GOOGLE_SECRET='${{ secrets.GOOGLE_SECRET }}' \
             --restart always \
             --name nestjs-bapull \
             hwangjungseok/nestjs-bapull:latest"


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?
EC2 환경에서 Google OAuth2 인증을 위해 GOOGLE_CLIENT_ID와 GOOGLE_SECRET 환경 변수를 전달하지 못해 발생하는 문제를 해결하고자 합니다. 현재 Docker 실행 시 OAuth2 클라이언트 정보가 누락되어, 인증 과정에서 오류가 발생하고 있습니다. 이 PR을 통해 해당 환경 변수를 EC2 환경의 Docker 실행 명령에 추가합니다.

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?
- Google OAuth2 클라이언트 정보(GOOGLE_CLIENT_ID, GOOGLE_SECRET)를 Docker 컨테이너 실행 시 환경 변수로 추가

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?
없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?
없음

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 작성해주세요.

-

## 📚 관련된 Issue나 Notion, 문서

> 이 PR이 해결하려는 문제와 관련된 Issue나 문서, Notion이 있다면 링크를 작성해주세요. Notion의 경우 [제목](링크) 형식으로 첨부해주세요.

-

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
