### PR TITLE
🔨refactor: Replace constants with enums in swagger annotations

### DIFF
--- a/src/incorrect-note/incorrect-note.controller.ts
+++ b/src/incorrect-note/incorrect-note.controller.ts
@@ -4,15 +4,16 @@ import { CreateIncorrectNoteDto } from './dto/create-incorrect-note.dto';
 import { UpdateIncorrectNoteDto } from './dto/update-incorrect-note.dto';
 import { ApiBody, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { GenerateIncorrectNoteDto } from './dto/generate-incorrect-note.dto';
-import { LangChainService } from 'src/lang-chain/lang-chain.service';
-import { ApiCommonResponses, ApiErrorResponse } from 'src/utils/swagger';
+import { LangChainService } from 'src/lang-chain/lang-chain.service'
 import { SaveIncorrectNoteDto } from './dto/save-incorrect-note.dto';
+import { ApiUnauthorizedResponses, ApiErrorResponse, ApiResponseMessage } from 'src/utils/swagger';
 
 
 
 @ApiTags('incorrect-note')
 @Controller('incorrect-note')
-@ApiCommonResponses()
+@ApiUnauthorizedResponses()
+@ApiErrorResponse('요청을 처리하지 못했습니다.')
 export class IncorrectNoteController {
   constructor(
     private readonly incorrectNoteService: IncorrectNoteService,
@@ -21,15 +22,7 @@ export class IncorrectNoteController {
 
   @ApiOperation({summary:'오답노트 저장하기'})
   @ApiBody({type: SaveIncorrectNoteDto})
-  @ApiResponse({
-    status: HttpStatus.CREATED,
-    description:'오답노트 저장완료',
-    schema: {
-      example: {
-        message: '오답노트를 저장했습니다.'
-      }
-    }
-  })
+  @ApiResponseMessage('오답노트 저장완료', HttpStatus.CREATED, '오답노트를 저장했습니다.')
   @Post('save')
   async saveNote(@Body() dto: SaveIncorrectNoteDto, @Req() request){
     if(request.user){
@@ -77,7 +70,6 @@ export class IncorrectNoteController {
   }
 
   @ApiOperation({summary:"오답노트 상세 정보 불러오기"})
-  @ApiErrorResponse()
   @ApiQuery({name:'note-name', example:'오답노트 파일명'})
   @ApiResponse({
     status: HttpStatus.OK,
@@ -169,15 +161,7 @@ export class IncorrectNoteController {
       }
     }
   })
-  @ApiResponse({
-    status: HttpStatus.BAD_REQUEST,
-    description:'쿼리파라미터가 필요함',
-    schema: {
-      example: {
-        message:'쿼리파라미터가 필요합니다.'
-      }
-    }
-  })
+  @ApiResponseMessage('쿼리파라미터가 필요함', HttpStatus.BAD_REQUEST, '쿼리파라미터가 필요합니다.')
   @Get()
   async findByLanguageAndErrorType(
     @Query('language') language: string,
@@ -199,7 +183,6 @@ export class IncorrectNoteController {
   }
 
   // @ApiOperation({summary:'(테스트용)오답노트 아이디로 오답노트 불러오기'})
-  // @ApiErrorResponse()
   // @Get(':id')
   // async findOne(@Param('id') noteId: string) {
   //   try{
@@ -226,7 +209,6 @@ export class IncorrectNoteController {
   // }
 
   @ApiOperation({summary:"(테스트용)오답노트 수정"})
-  @ApiErrorResponse()
   @Put(':id')
   @UsePipes(new ValidationPipe({whitelist: true, forbidNonWhitelisted: true}))
   async update(@Param('id') id: string, @Body() updateIncorrectNoteDto: UpdateIncorrectNoteDto) {
@@ -249,7 +231,6 @@ export class IncorrectNoteController {
   }
 
   @ApiOperation({summary:"(테스트용)오답노트 삭제"})
-  @ApiErrorResponse()
   @Delete(':id')
   async remove(@Param('id') id: string) {
     try{
@@ -271,7 +252,6 @@ export class IncorrectNoteController {
   }
 
   @ApiOperation({summary:"(테스트용)오답노트 추가"})
-  @ApiErrorResponse()
   @Post()
   @UsePipes(new ValidationPipe({whitelist: true, forbidNonWhitelisted: true}))
   async create(@Body() createIncorrectNoteDto: CreateIncorrectNoteDto) {
@@ -295,7 +275,6 @@ export class IncorrectNoteController {
   }
 
   @ApiOperation({summary:"(테스트용)멘토 아이디로 오답노트 불러오기"})
-  @ApiErrorResponse()
   @Get('mento')
   async findForMento(@Query('id') mentoId: string) {
     try{
@@ -322,7 +301,6 @@ export class IncorrectNoteController {
   }
 
   @ApiOperation({summary:"(테스트용)학생 아이디로 오답노트 불러오기"})
-  @ApiErrorResponse()
   @Get('student')
   async findForStudent(@Query('id') studentId: string) {
     try{

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -5,11 +5,12 @@ import { IncorrectNoteService } from 'src/incorrect-note/incorrect-note.service'
 import { ApiBody, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UpdateUserNameDto } from './dto/update-user-name.dto';
 import { UpdateUserLanguageDto } from './dto/update-user-language.dto';
-import { ApiCommonResponses } from 'src/utils/swagger';
+import { ApiUnauthorizedResponses, ApiErrorResponse, ApiResponseMessage } from 'src/utils/swagger';
 
 @ApiTags('user')
 @Controller('user')
-@ApiCommonResponses()
+@ApiUnauthorizedResponses()
+@ApiErrorResponse('요청을 처리하지 못했습니다.')
 export class UserController {
   constructor(private readonly userService: UserService,
     private readonly attendanceService: AttendanceService,
@@ -71,13 +72,7 @@ export class UserController {
   }
 
   @ApiOperation({ summary: '출석체크 추가' })
-  @ApiResponse({
-    status: HttpStatus.CREATED,
-    description: '출석체크 완료',
-    example:{
-      message:'출석체크를 완료했습니다.',
-    }
-  })
+  @ApiResponseMessage('출석체크 완료', HttpStatus.CREATED, '출석체크를 완료했습니다.')
   @Post('attendance')
   async makeAttendance(@Req() request){
     const date = new Date()
@@ -131,11 +126,7 @@ export class UserController {
       }
     }
   })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    description: '이름변경 완료',
-    example:{message:'이름이 변경되었습니다.'}
-  })
+  @ApiResponseMessage('이름변경 완료', HttpStatus.OK, '이름이 변경되었습니다.')
   @Patch('name')
   async changeName(@Req() request, @Body() dto:UpdateUserNameDto){
     if(request.user) {
@@ -161,20 +152,8 @@ export class UserController {
       }
     }
   })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    description: '언어변경 완료',
-    example:{message:'유저의 언어를 변경했습니다.'}
-  })
-  @ApiResponse({
-    status: 400,
-    description: 'body가 올바르지 않은 경우',
-    example:{
-      message: "useLanguage는 문자열 배열을 따옴표로 감싼 형태여야 합니다.",
-      error: "Bad Request",
-      statusCode: 400
-    }
-  })
+  @ApiResponseMessage('언어변경 완료', HttpStatus.OK, '언어를 변경했습니다.')
+  @ApiResponseMessage('body가 올바르지 않은 경우', HttpStatus.BAD_REQUEST, 'useLanguage는 문자열 배열을 따옴표로 감싼 형태여야 합니다.')
   @Patch('language')
   async changeLanguage(@Req() request, @Body() dto:UpdateUserLanguageDto){
     if(request.user) {
@@ -193,11 +172,7 @@ export class UserController {
   }
 
   @ApiOperation({summary:'유저 역할 변경(튜터에서 튜티로, 튜티에서 튜터로)'})
-  @ApiResponse({
-    status: HttpStatus.OK,
-    description: '역할변경 완료',
-    example:{message:'유저의 역할을 변경했습니다.'}
-  })
+  @ApiResponseMessage('역할변경 완료', HttpStatus.OK, '역할을 변경했습니다.')
   @Patch('position')
   async changePosition(@Req() request){
     if(request.user) {

--- a/src/utils/swagger.ts
+++ b/src/utils/swagger.ts
@@ -1,9 +1,9 @@
 import { HttpStatus } from "@nestjs/common";
 import { ApiResponse } from "@nestjs/swagger";
 
-export const ApiCommonResponses = () => {
+export const ApiUnauthorizedResponses = () => {
   return ApiResponse({
-    status: 401,
+    status: HttpStatus.UNAUTHORIZED,
     description: '로그인이 필요함',
     schema: {
       example: {
@@ -13,15 +13,27 @@ export const ApiCommonResponses = () => {
   });
 };
 
-export const ApiErrorResponse = () => {
+export const ApiErrorResponse = (message: string) => {
   return ApiResponse({
-    status: 400,
+    status: HttpStatus.BAD_REQUEST,
     description: '요청 실패',
     schema: {
       example: {
         STATUS_CODES: HttpStatus.BAD_REQUEST,
         message: '요청을 처리하지 못했습니다.',
-        error: '에러 메시지'
+        error: message
+      }
+    }
+  });
+};
+
+export const ApiResponseMessage = (description: string, status: number, message: string) => {
+  return ApiResponse({
+    status: status,
+    description: description,
+    schema: {
+      example: {
+        message: message
       }
     }
   });


### PR DESCRIPTION
🔨refactor: Replace constants with enums in swagger annotations
- Updated swagger annotations to use enums instead of constants.
- Moved duplicated parts to utils/swagger.ts and updated references accordingly.

## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

> swagger 어노테이션에서 중복되는 부분을 간소화. 상태코드를 숫자를 하드코딩으로 넣지 말고, enum을 사용하게 변경

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

> 문제를 해결하면서 주요 변경 사항을 작성해주세요.

- swagger 어노테이션 표기방식 변경

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

> 없으면 "없음"이라고 작성해주세요.

- 없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?

> 개발 과정에서 다른 사람의 의견이 궁금하거나, 크로스 체크가 필요하다고 느낀 코드가 있으면 알려주세요.

-

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 작성해주세요.

-

## 📚 관련된 Issue나 Notion, 문서

> 이 PR이 해결하려는 문제와 관련된 Issue나 문서, Notion이 있다면 링크를 작성해주세요. Notion의 경우 [제목](링크) 형식으로 첨부해주세요.

-

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
