### PR TITLE
OpenAI API 키 환경변수 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,6 +36,7 @@ jobs:
             -e SSL_CERT='${{ secrets.CERT_PEM }}' \
             -e GOOGLE_CLIENT_ID='${{ secrets.GOOGLE_CLIENT_ID }}' \
             -e GOOGLE_SECRET='${{ secrets.GOOGLE_SECRET }}' \
+            -e OPEN_API_KEY='${{ secrets.OPEN_API_KEY }}' \
             -e NODE_ENV='EC2' \
             --restart always \
             --name nestjs-bapull \


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?
EC2 인스턴스의 Docker 컨테이너에서 OPEN_API_KEY is not set 오류가 발생하여, GitHub Actions CD 워크플로우에서 OpenAI API 키를 환경변수로 전달하지 않는 문제를 해결하고자 합니다.


## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?
GitHub Actions CD 워크플로우 파일(cd.yml)에 OpenAI API 키를 환경변수로 추가:


## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?
없음

## 🙏🏻 리뷰어가 특히 봐주었으면 하는 부분은 무엇인가요?
없음

## 🩺 이 PR로 테스트나 검증이 필요한 부분이 있나요?

1. GitHub Actions 워크플로우 실행 시 배포 로그 확인
2.  EC2 인스턴스에서 Docker 컨테이너 실행 후 환경변수 설정 확인
3.  OpenAI 관련 기능 정상 동작 확인

## 📚 관련된 Issue나 Notion, 문서

> 이 PR이 해결하려는 문제와 관련된 Issue나 문서, Notion이 있다면 링크를 작성해주세요. Notion의 경우 [제목](링크) 형식으로 첨부해주세요.

-

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
