### PR TITLE
더 나은 멘토 로딩 방식

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,6 +4,8 @@ import { Request, Response } from 'express';
 import { ApiExcludeEndpoint, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { String } from 'aws-sdk/clients/apigateway';
+import { AuthGuard } from './auth.guard';
+import { ApiUnauthorizedResponses } from 'src/common/api-response.decorator';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -57,6 +59,8 @@ export class AuthController {
       ]
     }
   })
+  @ApiUnauthorizedResponses()
+  @UseGuards(AuthGuard)
   @Get('mento')
   async getFiveMento(@Query('language') language:string){
     return {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -13,3 +13,9 @@ export type Room = {
   receiver:string;
   sender:string
 }
+export type SessionData = {
+  cookie:object,
+  passport:{
+    user:number
+  }
+}

--- a/src/setting/init.sesstion.ts
+++ b/src/setting/init.sesstion.ts
@@ -23,11 +23,12 @@ export function setUpSession(app: INestApplication): void {
         resave:false,
         saveUninitialized:false,
         store: redisStore,
+        rolling:true,
         cookie:{
           secure:true,
           sameSite:'none',
-          maxAge: 36000000, //10시간
-        }
+          maxAge: 1000 * 60 * 30,
+        },
       }),
   );
   app.use(passport.initialize());

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -19,38 +19,6 @@ export class UserController {
     private readonly incorrectNoteService: IncorrectNoteService
   ) {}
 
-  @ApiOperation({summary:'멘토 5명 정보 호출'})
-  @ApiQuery({
-    name:'language',
-    description:'요청할 멘토의 언어',
-    example:'Java'
-  })
-  @ApiResponse({
-    status:HttpStatus.OK,
-    description:'멘토의 정보 배열',
-    example:{
-      'message':'멘토 정보를 성공적으로 불러왔습니다.',
-      'info': [
-        {
-          id:'1',
-          name:'문성윤',
-          useLanguage:'[\"Java\",\"Python\"]',
-          position:1,
-          profilePicture:'http://imgurl.com',
-          googleId:'1578648432159'
-        }
-      ]
-    }
-  })
-  @Get('mento')
-  async getFiveMento(@Req() request, @Query('language') language){
-    return {
-      'message':'멘토 정보를 성공적으로 불러왔습니다.',
-      'info': await this.userService.findFiveMento(language)
-    }
-  }
-
-
   @ApiOperation({summary:'유저 정보 호출'})
   @ApiResponse({
     status:HttpStatus.OK,


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

> 멘토를 불러올때, 접속중인 사람이 우선시 되지 않음
> 세션 유지시간이 너무 길어서, 세션에 정보가 들어있다고 한들, 접속중이라고 볼 수 없음

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

> 문제를 해결하면서 주요 변경 사항을 작성해주세요.

- 접속중인 유저에서 먼저 조건에 맞는 멘토를 찾고, 만약 5명이 안 된다면, 부족한 만큼 멘토를 db에서 찾아오게 수정했습니다.
- 접속중인 유저정보의 isActive 프로퍼티는 true이고, 아닌 사람은 false로 뜨게 해서 구분이 가능합니다.
- 세션 유지시간을 10시간에서 30분으로 변경하고, api 요청이 있을 때 마다, 시간을 갱신하게 하였습니다.

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

> 없으면 "없음"이라고 작성해주세요.

- 없음

## 📚 관련된 Issue나 Notion, 문서

> 이 PR이 해결하려는 문제와 관련된 Issue나 문서, Notion이 있다면 링크를 작성해주세요. Notion의 경우 [제목](링크) 형식으로 첨부해주세요.

- #72 

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
