### PR TITLE
오답노트 중복저장 문제 해결, 오답노트 저장할 때 저장된 노트의 아이디도 반환

### DIFF
--- a/src/incorrect-note/dto/save-incorrect-note.dto.ts
+++ b/src/incorrect-note/dto/save-incorrect-note.dto.ts
@@ -1,7 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, Matches, IsIn } from 'class-validator';
+import { IsString, Matches, IsIn, IsNumber } from 'class-validator';
 
 export class SaveIncorrectNoteDto {
+
+  @ApiProperty({
+    example:123213,
+    description:'중복확인을 위한 임의의 숫자'
+  })
+  @IsNumber()
+  id:number
+
   @ApiProperty({
     example: 'Python',
     description: '언어'

--- a/src/incorrect-note/entities/incorrect-note.entity.ts
+++ b/src/incorrect-note/entities/incorrect-note.entity.ts
@@ -1,6 +1,7 @@
-import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, PrimaryGeneratedColumn, Unique } from "typeorm";
 
 @Entity()
+@Unique(['studentId','noteName','language'])
 export class IncorrectNote {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/incorrect-note/incorrect-note.service.ts
+++ b/src/incorrect-note/incorrect-note.service.ts
@@ -16,6 +16,7 @@ export class IncorrectNoteService {
   ) {}
 
   async saveNote(dto: SaveIncorrectNoteDto, userId: number) {
+    let savedNote = null;
     const queryRunner = await this.dataSource.createQueryRunner()
     await queryRunner.connect()
     await queryRunner.startTransaction()
@@ -26,16 +27,16 @@ export class IncorrectNoteService {
       newNote.language = dto.language,
       newNote.errorType = parseInt(dto.errorType)
       newNote.studentId = userId,
-      newNote.noteName = mdFile.Key.replace('incorrect-notes/','')
-      await queryRunner.manager.save(IncorrectNote, newNote)
+      newNote.noteName = `${dto.id}` + mdFile.Key.replace('incorrect-notes/','').replace('..','.') 
+      savedNote = await queryRunner.manager.save(IncorrectNote, newNote)
       await queryRunner.commitTransaction()
     }catch(e){
       await queryRunner.rollbackTransaction()
-      console.error(e)
       throw e
     }finally{
       await queryRunner.release()
     }
+    return savedNote
   }
 
   async downloadMdFile(fileName:string, userId:number, userPosition:number){

--- a/src/s3/s3.service.ts
+++ b/src/s3/s3.service.ts
@@ -18,7 +18,7 @@ export class S3Service {
 
   async uploadMdFile(content: string, fileName?: string): Promise<AWS.S3.ManagedUpload.SendData> {
     
-    const key = fileName ? `incorrect-notes/${fileName}-${uuid()}.md` : `incorrect-notes/${uuid()}.md`;
+    const key = fileName ? `incorrect-notes/${fileName}.md` : `incorrect-notes/no-name.md`;
 
     const params: AWS.S3.PutObjectRequest = {
       Bucket: this.bucketName,


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

> 노트를 저장할 때 저장된 노트의 아이디가 바로 반환이 되지 않아서 바로 채팅을 할 수 없는 문제가 있었다.
하나의 오답노트가 여러번 저장되는 문제가 있었다.

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

> 문제를 해결하면서 주요 변경 사항을 작성해주세요.

-  노트가 중복저장되지 않게 수정했다. 
- 노트를 저장할 때 노트의 아이디를 반환해서, 바로 채팅을 할 수 있게 하였다.

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

> 없으면 "없음"이라고 작성해주세요.

- 없음

## 📚 관련된 Issue나 Notion, 문서

> 이 PR이 해결하려는 문제와 관련된 Issue나 문서, Notion이 있다면 링크를 작성해주세요. Notion의 경우 [제목](링크) 형식으로 첨부해주세요.

- #80 

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
