### PR TITLE
캐시를 활용해서 멘토 저장 결과 저장

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@langchain/core": "^0.3.13",
         "@langchain/openai": "^0.3.8",
+        "@nestjs/cache-manager": "^2.3.0",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.2.3",
         "@nestjs/core": "^10.0.0",
@@ -22,6 +23,7 @@
         "@nestjs/typeorm": "^10.0.2",
         "@nestjs/websockets": "^10.4.6",
         "aws-sdk": "^2.1691.0",
+        "cache-manager": "^5.7.6",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "connect-redis": "^7.1.1",
@@ -1696,6 +1698,17 @@
       "peer": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@nestjs/cache-manager": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/cache-manager/-/cache-manager-2.3.0.tgz",
+      "integrity": "sha512-pxeBp9w/s99HaW2+pezM1P3fLiWmUEnTUoUMLa9UYViCtjj0E0A19W/vaT5JFACCzFIeNrwH4/16jkpAhQ25Vw==",
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "cache-manager": "<=5",
+        "rxjs": "^7.0.0"
       }
     },
     "node_modules/@nestjs/cli": {
@@ -3651,6 +3664,30 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/cache-manager": {
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-5.7.6.tgz",
+      "integrity": "sha512-wBxnBHjDxF1RXpHCBD6HGvKER003Ts7IIm0CHpggliHzN1RZditb7rXoduE1rplc2DEFYKxhLKgFuchXMJje9w==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "^10.2.2",
+        "promise-coalesce": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/cache-manager/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/cache-manager/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/call-bind": {
       "version": "1.0.7",
@@ -7248,6 +7285,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -8488,6 +8530,14 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/promise-coalesce": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/promise-coalesce/-/promise-coalesce-1.1.2.tgz",
+      "integrity": "sha512-zLaJ9b8hnC564fnJH6NFSOGZYYdzrAJn2JUUIwzoQb32fG2QAakpDNM+CZo1km6keXkRXRM+hml1BFAPVnPkxg==",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/prompts": {
       "version": "2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@nestjs/websockets": "^10.4.6",
         "aws-sdk": "^2.1691.0",
         "cache-manager": "^5.7.6",
+        "cache-manager-redis-yet": "^5.1.5",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "connect-redis": "^7.1.1",
@@ -3674,6 +3675,25 @@
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "^10.2.2",
         "promise-coalesce": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/cache-manager-redis-yet": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/cache-manager-redis-yet/-/cache-manager-redis-yet-5.1.5.tgz",
+      "integrity": "sha512-NYDxrWBoLXxxVPw4JuBriJW0f45+BVOAsgLiozRo4GoJQyoKPbueQWYStWqmO73/AeHJeWrV7Hzvk6vhCGHlqA==",
+      "deprecated": "With cache-manager v6 we now are using Keyv",
+      "dependencies": {
+        "@redis/bloom": "^1.2.0",
+        "@redis/client": "^1.6.0",
+        "@redis/graph": "^1.1.1",
+        "@redis/json": "^1.0.7",
+        "@redis/search": "^1.2.0",
+        "@redis/time-series": "^1.1.0",
+        "cache-manager": "^5.7.6",
+        "redis": "^4.7.0"
       },
       "engines": {
         "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nestjs/websockets": "^10.4.6",
     "aws-sdk": "^2.1691.0",
     "cache-manager": "^5.7.6",
+    "cache-manager-redis-yet": "^5.1.5",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "connect-redis": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@langchain/core": "^0.3.13",
     "@langchain/openai": "^0.3.8",
+    "@nestjs/cache-manager": "^2.3.0",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.2.3",
     "@nestjs/core": "^10.0.0",
@@ -34,6 +35,7 @@
     "@nestjs/typeorm": "^10.0.2",
     "@nestjs/websockets": "^10.4.6",
     "aws-sdk": "^2.1691.0",
+    "cache-manager": "^5.7.6",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "connect-redis": "^7.1.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,11 +28,18 @@ import { WinstonModule } from 'nest-winston';
 import { APP_FILTER } from '@nestjs/core';
 import { HttpFilter } from './setting/http.filter';
 import { CacheModule } from '@nestjs/cache-manager';
+import { redisStore } from 'cache-manager-redis-yet';
 @Module({
   imports: [
-    CacheModule.register({
+    CacheModule.registerAsync({
       isGlobal: true,
-      ttl: 60000 // 60s
+      inject:[ConfigService],
+      useFactory:async (config: ConfigService)=>({
+        ttl: 60000,
+        store: await redisStore({
+          url:config.get<string>('REDIS_URL')
+        })
+      })
     }),
     ConfigModule.forRoot({
       isGlobal: true

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -27,8 +27,13 @@ import * as winston from 'winston'
 import { WinstonModule } from 'nest-winston';
 import { APP_FILTER } from '@nestjs/core';
 import { HttpFilter } from './setting/http.filter';
+import { CacheModule } from '@nestjs/cache-manager';
 @Module({
   imports: [
+    CacheModule.register({
+      isGlobal: true,
+      ttl: 60000 // 60s
+    }),
     ConfigModule.forRoot({
       isGlobal: true
     }),

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,14 +1,17 @@
-import { BadGatewayException, Inject, Injectable, LoggerService } from '@nestjs/common';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { UserService } from 'src/user/user.service';
 import { SessionData, UserDetails } from 'src/common/types';
 import { createClient } from "redis";
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
 
 @Injectable()
 export class AuthService {
   private redisClient;
   constructor(
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
     private readonly userService: UserService,
     private readonly configService: ConfigService,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger:LoggerService
@@ -75,6 +78,10 @@ export class AuthService {
   }
 
   async findAllMento(language:string){
+    const value = await this.cacheManager.get(`mento:${language}`);
+    if(value){
+      return value
+    }
     try{
       let cursor = 0
       const sessions:number[] = [];

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -87,7 +87,7 @@ export class AuthService {
       const sessions:number[] = [];
 
       do{
-        const reply = await this.redisClient.scan(cursor, 'MATCH','sess:*','COUNT','100')
+        const reply = await this.redisClient.scan(cursor, {MATCH: 'sess:*',COUNT: 100})
         cursor = reply['cursor'];
         const keys:string[] = reply['keys'];
         const sessionDatas:number[] = await Promise.all(keys.map(async (key)=>{

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -6,10 +6,13 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 import { DataSource, Repository } from 'typeorm';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
 
 @Injectable()
 export class UserService {
   constructor(
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
     private readonly dataSource:DataSource,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger:LoggerService
   ){}
@@ -161,7 +164,7 @@ export class UserService {
         response.push(...appendPropertyNotActive)
       }
       
-      
+      await this.cacheManager.set(`mento:${language}`, response);
       return response
     }catch(e){
       if (e instanceof Error) {


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

> 멘토 검색은 서버에 부하를 많이 주는 로직임

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

> 문제를 해결하면서 주요 변경 사항을 작성해주세요.

- 멘토검색 결과를 언어별로 redis에 저장하고 ttl을 1분으로 설정함. 만약 redis에 검색결과가 남아있을 경우 해당 값을 바로 리턴하게 해서 같은 언어로 멘토 검색이 들어오는 경우 빠르게 응답할 수 있음

ab -n 1000 -c 10 https://localhost:3000/auth/mento 이 명령어로 테스트 해보았을 때
캐시 적용전 4.525 이었던 응답시간이 2.711 로 감소함

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

> - auth.service.ts의 findAllMento 메소드에서 redisClient의 scan를 호출할때 잘못된 인수를 전달하고 있던 부분을 수정

## 📚 관련된 Issue나 Notion, 문서

> 이 PR이 해결하려는 문제와 관련된 Issue나 문서, Notion이 있다면 링크를 작성해주세요. Notion의 경우 [제목](링크) 형식으로 첨부해주세요.

- #65 

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
